### PR TITLE
Fixed speeding upp bug

### DIFF
--- a/html/main.js
+++ b/html/main.js
@@ -105,8 +105,8 @@ function SetVolume(volume) {
             player.setVolume(volume / 100.0);
         }
         else if (playerData.type == "youtube") {
-            player.setVolume(volume);
             player.unMute();
+            player.setVolume(volume);
         }
     }
 }


### PR DESCRIPTION
The player.unMute(); function sets the volume to 5 by default. So calling a difrent under 5 before makes the video feel faster